### PR TITLE
safariでカレンダーの日付切り替えが機能していないバグを修正。

### DIFF
--- a/frontend/components/shared/sidebar-calendar.vue
+++ b/frontend/components/shared/sidebar-calendar.vue
@@ -152,7 +152,7 @@ export default {
       }
       const year = this.currentMoment.year(); // 表示するyearを取得
       const month = this.currentMoment.month() + 1; // 表示するmonthを取得
-      const selectedDate = `${year}-${month}-${date}`;
+      const selectedDate = `${year}/${month}/${date}`;
       this.setSelectedDateAction(selectedDate);
     },
     todoMatchCalendar() {
@@ -165,8 +165,6 @@ export default {
       this.current += year_difference * 12 + month_difference * 1;
     },
     fetchToday() {
-      this.current = 0;
-      const selectedDate = moment().format('YYYY-MM-DD');
       this.setSelectedDateAction(moment());
     }
   }


### PR DESCRIPTION
・JavsScriptのDate型はブラウザによってparseできるものとできないものがある。
・今回原因となっていたのはDate型にハイフンが使われた文字列を引数として与えた場合に、safariがparseできていなかった。
・文字列内のハイフンをスラッシュ(/)に置き換えることで、safariでDate変換が正常起動することを確認。