### PR TITLE
Todo一覧表示で順番が正しく表示できないバグを解決。

### DIFF
--- a/backend/app/controllers/api/v1/todos_controller.rb
+++ b/backend/app/controllers/api/v1/todos_controller.rb
@@ -8,7 +8,7 @@ module Api
                              .include_labels
                              .search(params[:search_query])
                              .match_date(params[:date])
-                             .order_todo_date_asc
+                             .order_date_and_time_asc
 
         render 'index', formats: :json, handlers: 'jbuilder'
       end

--- a/backend/app/models/todo.rb
+++ b/backend/app/models/todo.rb
@@ -6,7 +6,7 @@ class Todo < ApplicationRecord
   has_many :labels, through: :todo_labels
 
   scope :include_labels, -> { includes([:labels]) }
-  scope :order_todo_date_asc, -> { order(todo_date: :asc) }
+  scope :order_date_and_time_asc, -> { order(todo_date: :asc).order(created_at: :asc) }
 
   scope :match_date, -> (date) do
     return unless date


### PR DESCRIPTION
・todo.rbにてtodo_date、created_atの両方をorderに設定。
・todos_controllerで呼び出しているscope名を修正。